### PR TITLE
Use `get_logger` fixture to test exception logged in debug.

### DIFF
--- a/tests/middleware/conftest.py
+++ b/tests/middleware/conftest.py
@@ -1,0 +1,20 @@
+from typing import TYPE_CHECKING
+
+import pytest
+
+from starlite.config.logging import LoggingConfig, default_handlers
+
+if TYPE_CHECKING:
+    from starlite.types.callable_types import GetLogger
+
+
+@pytest.fixture
+def get_logger() -> "GetLogger":
+    # due to the limitations of caplog we have to place this call here.
+    # we also have to allow propagation.
+    return LoggingConfig(
+        handlers=default_handlers,
+        loggers={
+            "starlite": {"level": "DEBUG", "handlers": ["queue_listener"], "propagate": True},
+        },
+    ).configure()

--- a/tests/middleware/test_exception_handler_middleware.py
+++ b/tests/middleware/test_exception_handler_middleware.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
     from starlite.datastructures import State
     from starlite.types import Scope
+    from starlite.types.callable_types import GetLogger
 
 
 async def dummy_app(scope: Any, receive: Any, send: Any) -> None:
@@ -140,7 +141,7 @@ def test_exception_handler_middleware_calls_app_level_after_exception_hook() -> 
     ],
 )
 def test_exception_handler_middleware_debug_logging(
-    caplog: "LogCaptureFixture", debug: bool, logging_config: Optional[LoggingConfig]
+    get_logger: "GetLogger", caplog: "LogCaptureFixture", debug: bool, logging_config: Optional[LoggingConfig]
 ) -> None:
     @get("/test")
     def handler() -> None:
@@ -149,6 +150,7 @@ def test_exception_handler_middleware_debug_logging(
     app = Starlite([handler], logging_config=logging_config, debug=debug)
 
     with caplog.at_level("DEBUG", "starlite"), TestClient(app=app) as client:
+        client.app.logger = get_logger("starlite")
         response = client.get("/test")
         assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
         assert "Test debug exception" in response.text

--- a/tests/middleware/test_logging_middleware.py
+++ b/tests/middleware/test_logging_middleware.py
@@ -6,7 +6,6 @@ from structlog.testing import capture_logs
 
 from starlite import Cookie, LoggingConfig, Response, StructLoggingConfig, get, post
 from starlite.config.compression import CompressionConfig
-from starlite.config.logging import default_handlers
 from starlite.middleware import LoggingMiddlewareConfig
 from starlite.status_codes import HTTP_200_OK
 from starlite.testing import create_test_client
@@ -24,18 +23,6 @@ def handler() -> Response:
         headers={"token": "123", "regular": "abc"},
         cookies=[Cookie(key="first-cookie", value="abc"), Cookie(key="second-cookie", value="xxx")],
     )
-
-
-@pytest.fixture
-def get_logger() -> "GetLogger":
-    # due to the limitations of caplog we have to place this call here.
-    # we also have to allow propagation.
-    return LoggingConfig(
-        handlers=default_handlers,
-        loggers={
-            "starlite": {"level": "INFO", "handlers": ["queue_listener"], "propagate": True},
-        },
-    ).configure()
 
 
 def test_logging_middleware_regular_logger(get_logger: "GetLogger", caplog: "LogCaptureFixture") -> None:


### PR DESCRIPTION
- moves get_logger fixture to conftest.py for middleware tests
- patches app logger in tests with one that propagates so caplog works.

# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
